### PR TITLE
(maint) Updating the cjc-manager python app to 0.1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM artifactory.delivery.puppetlabs.net/qe/dockerwithbolt:dcf8d9e11fd78c60f9cf8e801dfab8da6013ff49
+RUN pip install --upgrade 'gitpython>=2.1.11'
+RUN pip install --upgrade cjc-manager -i https://artifactory.delivery.puppetlabs.net/artifactory/api/pypi/pypi__local/simple


### PR DESCRIPTION
this new version includes a fix for the thinpool reset process.
cjc was failing to put nodes in offline mode, because of
auth issues with breadcrumbs. The new code uses the
jenkins library which support auth requests